### PR TITLE
fixed detection of spam field value for string position 0 cases

### DIFF
--- a/Plugin/Customer/Controller/Account/CreatePostPlugin.php
+++ b/Plugin/Customer/Controller/Account/CreatePostPlugin.php
@@ -31,7 +31,7 @@ class CreatePostPlugin
 
         foreach ($spamContent as $entry) {
             foreach ($formFieldsToCheck as $field) {
-                if (strpos($data[$field], $entry)) {
+                if (strpos($data[$field], $entry) !== false) {
                     $spam = true;				
                 }
             }


### PR DESCRIPTION
For detecting of spam-strings in posted values, this previous check did not work when a spam-value was at position 0 of the posted field (for example if the posted firstname field equals _http://_):

`if (strpos($data[$field], $entry)) {`

I changed the check to the following, which properly detects a spam-word if the posted value *starts with* that spam-word (spam-word is at position 0 of the posted value):

`if (strpos($data[$field], $entry) !== false) {`

php strpos documentation: _Returns <b>FALSE</b> if the needle was not found._